### PR TITLE
Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,57 @@
-# Astro Starter Kit: Minimal
+# workingon.studio
 
-```sh
-npm create astro@latest -- --template minimal
-```
+Look, I'm tired of products that pretend to solve problems while creating new ones. Tired of "user experiences" designed to extract rather than delight. Tired of the gap between what we say we're building and what we're actually building.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+So I'm building things differently.
 
-## 🚀 Project Structure
+## What I actually do.
 
-Inside of your Astro project, you'll see the following folders and files:
+I make cultural mirror products. Things that hold up what people are unconsciously doing and make them suddenly, uncomfortably aware of it.
 
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
+[**Dad Reply**](https://www.producthunt.com/products/dad-reply) - Universal acknowledgment without engagement.
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+[**Solidarity**](https://chromewebstore.google.com/detail/ahahliplongfboaikbajdedefpoifjeb?utm_source=item-share-cb) - Everyone's looking for something.
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+**Design Dojo** - When creativity becomes competition.
 
-Any static assets, like images, can be placed in the `public/` directory.
+**Only98** - How much will you spend to be truly unique?
 
-## 🧞 Commands
+**TypeDrop** - What does thinking cost?
 
-All commands are run from the root of the project, from a terminal:
+Each one works. Each one also makes you think about why you needed it in the first place.
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+## The thing about this site.
 
-## 👀 Want to learn more?
+Here's where it gets interesting.
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Instead of hiding our messy development process behind polished marketing copy, we made it the centrepiece. See that "Last updated" timestamp? Click it.
+
+You'll see every commit, every iteration, every small improvement. The actual development timeline, auto-generated from git commits. No sanitised "our process" nonsense—just the real process, visible and unfiltered.
+
+Because transparency isn't just philosophy. It's practice.
+
+## Why this matters.
+
+I don't ask people to abandon existing systems. That's naive and ineffective. Instead, I meet them where they are and change how they interact with those systems.
+
+Rather than preaching about digital wellness, I build Dad Reply. Instead of lecturing about LinkedIn's toxicity, I create Solidarity. I don't write manifestos about AI's environmental cost—I make TypeDrop.
+
+Each product is both functional tool and cultural commentary, delivered through experience rather than explanation.
+
+## How I work.
+
+No compartmentalisation. The same methodology driving experimental projects shapes client work. A design studio crossed with a sociology lab where each release makes invisible dynamics suddenly apparent.
+
+I don't just make things look good. I make things that make you question why they needed to exist at all.
+
+## What's next.
+
+Currently working on making the obvious visible. Working on centering people in technology. Working on finding delight in the mundane.
+
+Always working on something.
+
+---
+
+Repository: [github.com/prmack/WorkingOn.studio](https://github.com/prmack/WorkingOn.studio)
+
+*Everything's transparent here. Even this README is version-controlled and visible in the timeline.*


### PR DESCRIPTION
This whole time I have ran with the Apollo default Readme. But no more. Updated to bring inline with what workingon.studio is about.

*edit : Should read **Astro** not **Apollo**.