### PR TITLE
Plausible, self hosted on Railway for analytics.

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,18 @@
 ---
 import '../styles/global.css';
 
+const isDev = import.meta.env.DEV;
+const plausibleDomain = isDev ? 'localhost' : 'workingon.studio';
+const plausibleScript = isDev 
+  ? 'https://plausible-analytics-ce-production-a4db.up.railway.app/js/script.local.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js'
+  : 'https://plausible-analytics-ce-production-a4db.up.railway.app/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js';
+
+declare global {
+  interface Window {
+    plausible: any;
+  }
+}
+
 export interface Props {
   title: string;
 }
@@ -26,6 +38,10 @@ const nudicaMonoFontUrl = import.meta.env.NUDICA_MONO_FONT_CSS_URL;
     <link href="https://fonts.googleapis.com/css2?family=Azeret+Mono:ital,wght@0,500;1,500&family=Space+Grotesk:wght@500&display=swap" rel="stylesheet">
     <meta name="generator" content={Astro.generator} />
     
+    <script defer data-domain={plausibleDomain} src={plausibleScript}></script>
+    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+
+
     <!-- CDN Font Stylesheets -->
     {nudicaFontUrl && <link rel="stylesheet" href={nudicaFontUrl} />}
     {nudicaMonoFontUrl && <link rel="stylesheet" href={nudicaMonoFontUrl} />}


### PR DESCRIPTION
Went the long way round with this one. Didn't want to use GA for analytics, despite it probably being easier to setup. Looked an [Umami](https://umami.is/) first, but had issues with deploying via Vercel. Then switched to [Posthog](https://posthog.com/), hosted, but found it to be a little overkill for the current iteration. Finally settled on [Plausible](https://plausible.io/) self hosted on [Railway](https://railway.com/).

It's lightweight, and doesn't track aggressively (using hashes for identity), which means no need for a cookie banner. Should be able to tap into the API so I can bring analytics into the main site (keeping things visible to all).

### TLDR

- Didn't want to use GA
- Went with Umami, had Vercel deployment issues.
- Switched to Posthog, overkill.
- Landed on Plausible, hosted on Railway.